### PR TITLE
API - compatibility with Py3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Requirements can be installed through Conda as ```conda install --file requireme
 
 If you wish to run tests:
 
-    make tests
+    make test
 
 ### Installing from source
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ StringDecomposer (SD) algorithm takes the set of monomers and a long error-prone
 Requirements:
 - Python3.5
     - [biopython](https://biopython.org/wiki/Download)
-    - [edlib](https://pypi.org/project/edlib/)
     - [argparse](https://pypi.org/project/argparse/)
     - [joblib](https://joblib.readthedocs.io/en/latest/installing.html)
+    - [networkx](https://pypi.org/project/networkx)
     - [numpy](https://scipy.org/install.html)
+    - [matplotlib](https://pypi.org/project/matplotlib/)
     - [pandas](https://pypi.org/project/pandas/)
+    - [python-edlib](https://pypi.org/project/edlib/)
+    - [seaborn](https://pypi.org/project/seaborn/)
     - [setuptools](https://pypi.org/project/setuptools/)
 - g++ (version 5.3.1 or higher)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 biopython
-edlib
 argparse
 joblib
+networkx
 numpy
+matplotlib
 pandas
+python-edlib
+seaborn
 setuptools

--- a/sd/cluster_sequences.py
+++ b/sd/cluster_sequences.py
@@ -44,11 +44,13 @@ def cluster_sequences(sequences, max_ident):
             identities[(s_id2, s_id1)] = ident
             if ident > max_ident:
                 graph.add_edge(s_id1, s_id2)
-                logger.info(f'Ident {ident:0.2} b/w {s_id1} and {s_id2}')
+                logger.info('Ident {:.2f} b/w {} and {}'.format(ident,
+                                                                s_id1,
+                                                                s_id2))
     clusters = list(nx.connected_components(graph))
-    logger.info(f'Extracted {len(clusters)} clusters')
-    n_nontrivial_clusters = sum(len(cluster) > 1 for cluster in clusters)
-    logger.info(f'Extracted {n_nontrivial_clusters} clusters of size > 1')
+    logger.info('Extracted {} clusters'.format(len(clusters)))
+    n_nontriv_clusters = sum(len(cluster) > 1 for cluster in clusters)
+    logger.info('Extracted {} clusters of size > 1'.format(n_nontriv_clusters))
     return clusters, identities
 
 
@@ -87,8 +89,8 @@ def main():
     logger = get_logger(logfn,
                         logger_name='SD: cluster sequences')
 
-    logger.info(f'cmd: {sys.argv}')
-    logger.info(f'git hash: {get_git_revision_short_hash()}')
+    logger.info('cmd: {}'.format(sys.argv))
+    logger.info('git hash: {}'.format(get_git_revision_short_hash()))
 
     sequences = read_bio_seqs(params.sequences)
     clusters, identities = \

--- a/sd/monomers/monomer_db.py
+++ b/sd/monomers/monomer_db.py
@@ -80,10 +80,10 @@ class MonomerDB:
         return monomer_db
 
     def get_ids(self):
-        return self.id2index.keys()
+        return sorted(self.id2index.keys())
 
     def get_monoindexes(self):
-        return self.index2id.keys()
+        return sorted(self.index2id.keys())
 
     def get_monomer_by_id(self, mono_id):
         return self.monomers[self.id2index[mono_id]]

--- a/sd/monomers/monomer_db.py
+++ b/sd/monomers/monomer_db.py
@@ -38,10 +38,10 @@ class MonomerDB:
     @classmethod
     def from_fasta_file(cls, fn, cluster_max_ident=0.95, tocluster=False):
         fn = expandpath(fn)
-        logger.info(f'Creating Monomer DataBase from {fn}')
+        logger.info('Creating Monomer DataBase from {}'.format(fn))
         raw_monomers = read_bio_seqs(fn)
-        logger.info(f'Clustering monomers.'
-                    f'Identity thresh {cluster_max_ident}')
+        logger.info('Clustering monomers.'
+                    'Identity thresh {}'.format(cluster_max_ident))
         if tocluster:
             monomer_clusters, _ = \
                 cluster_sequences(sequences=raw_monomers,
@@ -64,8 +64,9 @@ class MonomerDB:
                 id2index[monomer_id] = i
                 index2id[i].append(monomer_id)
                 id2list_coord[monomer_id] = len(monomers) - 1
-                logger.debug(f'Monomer: index = {i} id = {monomer_id}')
-                logger.debug(f'         monomer sequence = {monomer_seq}')
+                logger.debug('Monomer: index = {} id = {}'.format(i,
+                                                                  monomer_id))
+                logger.debug('         monomer seq = {}'.format(monomer_seq))
 
         monomer_db = cls(id2index=id2index,
                          index2id=index2id,
@@ -73,7 +74,7 @@ class MonomerDB:
                          id2list_coord=id2list_coord,
                          clustered=tocluster)
 
-        logger.info(f'Finished Creating Monomer DataBase')
+        logger.info('Finished Creating Monomer DataBase')
         return monomer_db
 
     def get_ids(self):

--- a/sd/monomers/monomer_db.py
+++ b/sd/monomers/monomer_db.py
@@ -19,9 +19,11 @@ class Monomer:
         self.seq = seq
 
     def __repr__(self):
-        return f'monomer_id={self.monomer_id}, '\
-               f'mono_index={self.mono_index}, '\
-               f'seq={self.seq}'
+        return 'monomer_id={self.monomer_id}, '\
+               'mono_index={self.mono_index}, '\
+               'seq={self.seq}'.format(self.monomer_id,
+                                       self.mono_index,
+                                       self.seq)
 
 
 class MonomerDB:
@@ -33,7 +35,7 @@ class MonomerDB:
         self.clustered = clustered
 
     def __repr__(self):
-        return f'size={self.get_size()}, ids={self.get_ids()}'
+        return 'size={}, ids={}'.format(self.get_size(), self.get_ids())
 
     @classmethod
     def from_fasta_file(cls, fn, cluster_max_ident=0.95, tocluster=False):

--- a/sd/monomers/monostring.py
+++ b/sd/monomers/monostring.py
@@ -146,21 +146,21 @@ class MonoString:
                     reliabilities.append(reliability)
                 return reliabilities
 
-            starts = sd_record.s_st.to_list()
+            starts = list(sd_record.s_st)
             ends = [en + 1 for en in sd_record.s_en]
 
-            ids = sd_record.monomer.to_list()
+            ids = list(sd_record.monomer)
             indexes_strands = map(id2index_strand, ids)
             indexes, strands = zip(*indexes_strands)
 
-            sec_ids = sd_record.sec_monomer.to_list()
+            sec_ids = list(sd_record.sec_monomer)
             sec_indexes_strands = map(id2index_strand, sec_ids)
             sec_indexes, sec_strands = zip(*sec_indexes_strands)
 
             identities = [ident / 100
-                          for ident in sd_record.identity.to_list()]
+                          for ident in sd_record.identity]
             sec_identities = [ident / 100
-                              for ident in sd_record.sec_identity.to_list()]
+                              for ident in sd_record.sec_identity]
 
             reliabilities = get_reliablities(sd_record=sd_record,
                                              identities=identities,

--- a/sd/monomers/monostring_set.py
+++ b/sd/monomers/monostring_set.py
@@ -122,7 +122,7 @@ class MonoStringSet:
         monostrings_filt_out = self.monostrings_filt_out
         monostrings_lens = [len(monostr) for monostr in monostrings.values()]
         stats['nmonostrings'] = len(monostrings_lens)
-        stats['nfiltered_out'] = len(monostrings_filt_out)
+        stats['nfilt_out'] = len(monostrings_filt_out)
         stats['min_len'] = np.min(monostrings_lens)
         stats['max_len'] = np.max(monostrings_lens)
         stats['mean_len'] = np.mean(monostrings_lens)
@@ -131,15 +131,16 @@ class MonoStringSet:
         stats['pgaps'] = stats['ngaps'] / stats['tot_len']
         stats['ngap_runs'] = get_ngap_symbols(monostrings, compr_hmp=True)
 
-        logger.info(f'# monostrings: {stats["nmonostrings"]}')
-        logger.info(f'# filtered monostrings: {stats["nfiltered_out"]}')
-        logger.info(f'Min length = {stats["min_len"]}')
-        logger.info(f'Mean length = {stats["mean_len"]}')
-        logger.info(f'Max length = {stats["max_len"]}')
-        logger.info(f'Total length = {stats["tot_len"]}')
+        logger.info('# monostrings: {}'.format(stats["nmonostrings"]))
+        logger.info('# filtered monostrings: {}'.format(stats["nfilt_out"]))
+        logger.info('Min length = {}'.format(stats["min_len"]))
+        logger.info('Mean length = {}'.format(stats["mean_len"]))
+        logger.info('Max length = {}'.format(stats["max_len"]))
+        logger.info('Total length = {}'.format(stats["tot_len"]))
 
-        logger.info(f'#(%) Gap symbols = {stats["ngaps"]} ({stats["pgaps"]})')
-        logger.info(f'#Gap runs = {stats["ngap_runs"]}')
+        logger.info('#(%) Gap symbols = {} ({})'.format(stats["ngaps"],
+                                                        stats["pgaps"]))
+        logger.info('# Gap runs = {}'.format(stats["ngap_runs"]))
         if return_stats:
             return stats
 

--- a/sd/sd_parser/sd_parser.py
+++ b/sd/sd_parser/sd_parser.py
@@ -21,11 +21,11 @@ class SD_Report:
         if mode is not None:
             assert mode in ['ont', 'hifi', 'assembly']
 
-        logger.info(f'Mode is {mode}')
+        logger.info('Mode is {}'.format(mode))
 
-        logger.info(f'    sd_report_fn = {sd_report_fn}')
-        logger.info(f'    monomers_fn  = {monomers_fn}')
-        logger.info(f'    sequences_fn = {sequences_fn}')
+        logger.info('    sd_report_fn = {}'.format(sd_report_fn))
+        logger.info('    monomers_fn  = {}'.format(monomers_fn))
+        logger.info('    sequences_fn = {}'.format(sequences_fn))
         monomer_db = MonomerDB.from_fasta_file(monomers_fn,
                                                tocluster=tocluster)
 

--- a/sd/utils/bio.py
+++ b/sd/utils/bio.py
@@ -2,6 +2,7 @@
 # This file is a part of the SD program.
 # see LICENSE file
 
+from collections import OrderedDict
 from itertools import groupby
 
 from Bio import SeqIO
@@ -20,8 +21,10 @@ def read_bio_seqs(filename):
         form = 'fasta'
     elif form == 'fq':
         form = 'fastq'
-    seqs = SeqIO.parse(filename, format=form)
-    seqs = {seq.id: str(seq.seq) for seq in seqs}
+    raw_seqs = SeqIO.parse(filename, format=form)
+    seqs = OrderedDict()
+    for seq in raw_seqs:
+        seqs[seq.id] = str(seq.seq)
     return seqs
 
 

--- a/sd/utils/bio.py
+++ b/sd/utils/bio.py
@@ -35,7 +35,7 @@ def RC(s):
 def write_bio_seqs(filename, seqs, width=60):
     with open(filename, 'w') as f:
         for seq_id, seq in seqs.items():
-            print(f'>{seq_id}', file=f)
+            print('>{}'.format(seq_id), file=f)
             if width is None:
                 print(seq, file=f)
                 continue

--- a/tests/_all_tests.py
+++ b/tests/_all_tests.py
@@ -26,8 +26,8 @@ def main():
                         level=logging.DEBUG,
                         filemode='w',
                         stdout=False)
-    logger.info(f'cmd: {sys.argv}')
-    logger.info(f'git hash: {get_git_revision_short_hash()}')
+    logger.info('cmd: {}'.format(sys.argv))
+    logger.info('git hash: {}'.format(get_git_revision_short_hash()))
 
     unittest.main()
 


### PR DESCRIPTION
Corrected:
- readme typo: make tests -> make test
- removed fstring
- order of dict is not guaranteed in earlier version of py (see [PEP468](https://www.python.org/dev/peps/pep-0468/#dict-order)
- Downgraded pandas to satisfy py3.5
- Updated requirements (including edlib->python-edlib)

tested on clean anaconda
```
conda create -n sd_api_testing python=3.5
conda activate sd_api_testing
conda install --file requirements.txt
make test
```